### PR TITLE
closes #37 ,#38

### DIFF
--- a/scripts/ec2_bot.coffee
+++ b/scripts/ec2_bot.coffee
@@ -117,9 +117,9 @@ module.exports = (robot) ->
 
 
   input_instanceId = (res, dialog, condition) ->
-    res.send "サーバの#{condition.value}ですね！インスタンスIDを教えてください。[instanceId を入力] もしくは[やめる,0]"
+    res.send "サーバの#{condition.value}ですね！インスタンスIDを教えてください。[instanceId を入力] もしくは[やめる,0,n]"
 
-    dialog.addChoice /\s(やめる|0)$/, (res2)->
+    dialog.addChoice /\s(やめる|0|n)$/, (res2)->
       res2.send "わかりました。#{condition.value}するのはやめます。"
 
     dialog.addChoice /(.*)/, (res2)->
@@ -128,15 +128,15 @@ module.exports = (robot) ->
 
 
   confirm = (instanceId, res, dialog, condition)->
-    res.send "#{instanceId} のインスタンスを#{condition.value}します。よろしいでしょうか？[はい,いいえ,ok,yes,no,1(ok),0(no)]"
+    res.send "#{instanceId} のインスタンスを#{condition.value}します。よろしいでしょうか？[はい,いいえ,ok,yes,no,y,n,1(ok),0(no)]"
 
-    dialog.addChoice /\s(yes|ok|OK|YES|はい|1)$/, (res2) ->
+    dialog.addChoice /\s(yes|ok|OK|YES|はい|1|y)$/, (res2) ->
       res2.send "わかりました！#{condition.value}します！！！"
 
       startInstance res2, instanceId if condition.key == 0
       stopInstance res2, instanceId if condition.key == 1
 
-    dialog.addChoice /\s(no|NO|いいえ|0)$/, (res2) ->
+    dialog.addChoice /\s(no|NO|いいえ|0|n)$/, (res2) ->
       res2.send "わかりました。#{condition.value}するのはやめます。"
 
 
@@ -147,10 +147,17 @@ module.exports = (robot) ->
         key = "previousIP_#{instance.InstanceId}"
         console.log key
         message += "----\n"
+        for tag in instance.Tags
+          message += "#{tag.Key}: #{tag.Value}\n" if tag.Key is "Name"
+        message += "Platform: " + instance.Platform + '\n'
+        message += "InstanceType: " + instance.InstanceType + '\n'
         message += "InstanceId: " + instance.InstanceId + '\n'
         message += "PublicDnsName: " + instance.PublicDnsName + '\n'
         message += "PublicIpAddress: " + instance.PublicIpAddress + '\n'
+        message += "PrivateDnsName: " + instance.PrivateDnsName + '\n'
+        message += "PrivateIpAddress: " + instance.PrivateIpAddress + '\n'
         message += "State: " + instance.State.Name + '\n'
+
         message += "前回とおなじIPですね" + '\n' if instance.PublicIpAddress == robot.brain.get(key)
         message += "----\n"
 

--- a/scripts/templates.coffee
+++ b/scripts/templates.coffee
@@ -35,7 +35,7 @@ module.exports = (robot) ->
     'hubot reg':
       'desc': 'どちらかに、完全一致。'
       'message': ()->
-        return "\s(やめる|0)$"
+        return "\\s(やめる|0)$"
 
 
   robot.respond /template\s(.*)/i, (res) ->


### PR DESCRIPTION
closes #37
closes #38

テンプレートのエスケープを見直し。
Yes/Noは、y/nでも通るようにした
サーバ情報表示Botは、プラットフォームもだす。